### PR TITLE
The xenstore_hash_flatten method now properly returns the flattened hash...

### DIFF
--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -282,7 +282,6 @@ module ForemanXen
         end
       end
       out_hash
-      @key = key
     end
   end
 end


### PR DESCRIPTION
Prior to this change, xenstore_hash_flatten always returned nil. That result caused no data to be added to the xenstore. 
