### PR TITLE
Update foreman_xen.gemspec

### DIFF
--- a/foreman_xen.gemspec
+++ b/foreman_xen.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 $:.push File.expand_path("../lib", __FILE__)
 
 # Maintain your gem's version:


### PR DESCRIPTION
For my install, Ruby crashed complaining about the special character ł in Michaeł Piotrowski from line 10 (s.authors).

Adding # encoding: utf-8 allowed Ruby to run without crashing. Error seen in browser below:

Web application could not be started

/usr/share/foreman/vendor/ruby/1.9.1/bundler/gems/foreman-xen-296b8d8107ec/foreman_xen.gemspec:10: invalid multibyte char (US-ASCII)
/usr/share/foreman/vendor/ruby/1.9.1/bundler/gems/foreman-xen-296b8d8107ec/foreman_xen.gemspec:10: invalid multibyte char (US-ASCII)
/usr/share/foreman/vendor/ruby/1.9.1/bundler/gems/foreman-xen-296b8d8107ec/foreman_xen.gemspec:10: syntax error, unexpected $end, expecting ']'
...  = ["Pavel Nemirovsky, Michał Piotrowski, Avi Israeli"]
...                               ^ (SyntaxError)
