### PR TITLE
Move deface dependency to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,3 @@ gemspec
 
 # To use debugger
 # gem 'debugger'
-
-gem 'deface'

--- a/foreman_xen.gemspec
+++ b/foreman_xen.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,locale}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
+  s.add_dependency "deface", "< 1.0"
   s.add_dependency "fog"
 end


### PR DESCRIPTION
Gemfile is only used at development-time, the gemspec matters otherwise.

(Replaces #16 against the correct branch.)