### PR TITLE
Fix vm description

### DIFF
--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -1,6 +1,11 @@
 module FogExtensions
   module Xenserver
     module Server
+      extend ActiveSupport::Concern
+
+
+      include ActionView::Helpers::NumberHelper
+
 
       attr_accessor :memory_min, :memory_max, :custom_template_name, :builtin_template_name
 
@@ -30,6 +35,10 @@ module FogExtensions
 
       def state
         power_state
+      end
+
+      def vm_description
+        _("VM Descr: %{cpus} CPUs and %{memory} memory") % {:cpus => vcpus_max, :memory => number_to_human_size(memory_max.to_i)}
       end
 
     end

--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -38,7 +38,7 @@ module FogExtensions
       end
 
       def vm_description
-        _("VM Descr: %{cpus} CPUs and %{memory} memory") % {:cpus => vcpus_max, :memory => number_to_human_size(memory_max.to_i)}
+        _("%{cpus} CPUs and %{memory} memory") % {:cpus => vcpus_max, :memory => number_to_human_size(memory_max.to_i)}
       end
 
     end


### PR DESCRIPTION
Hi,

please merge the patch below as a fix for editing compute profiles in foreman 1.6 and 1.7 with foreman-xen. This method is mostly nearly identical to the libvirt-variant shipped with foreman.

This fixes this issue: http://projects.theforeman.org/issues/8410

Cheers, Nick
