### PR TITLE
fixes #8140: add 'vm_description' method to xenserver fog_extension

### DIFF
--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -1,6 +1,11 @@
 module FogExtensions
   module Xenserver
     module Server
+      extend ActiveSupport::Concern
+
+
+      include ActionView::Helpers::NumberHelper
+
 
       attr_accessor :memory_min, :memory_max, :custom_template_name, :builtin_template_name
 
@@ -30,6 +35,10 @@ module FogExtensions
 
       def state
         power_state
+      end
+
+      def vm_description
+        _("%{cpus} CPUs and %{memory} memory") % {:cpus => vcpus_max, :memory => number_to_human_size(memory_max.to_i)}
       end
 
     end


### PR DESCRIPTION
This is an updated pull request based on the comments in #18. 