### PR TITLE
Relax deface dependency to permit 1.x

### DIFF
--- a/foreman_xen.gemspec
+++ b/foreman_xen.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,locale}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "deface", "< 1.0"
+  s.add_dependency "deface", "< 2.0"
 end


### PR DESCRIPTION
Looks like app/overrides/ supports both 0.x and 1.x, and I'm in the process of updating Foreman repositories to use 1.x so allow it.

https://groups.google.com/forum/#!topic/foreman-dev/VTT6zugH3qo