### PR TITLE
fix host page when no CRs are installed

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,7 +59,7 @@ Metrics/LineLength:
 # Offense count: 19
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 64
+  Max: 66
 
 # Offense count: 7
 Metrics/PerceivedComplexity:

--- a/app/models/concerns/foreman_xen/host_helper_extensions.rb
+++ b/app/models/concerns/foreman_xen/host_helper_extensions.rb
@@ -7,9 +7,11 @@ module ForemanXen
         button_group(
           link_to_if_authorized(_('Edit'), hash_for_edit_host_path(:id => host).merge(:auth_object => host),
                                 :title => _('Edit your host'), :id => 'edit-button'),
-          unless host.compute_resource.nil? && host.compute_resource.type == 'ForemanXen::Xenserver'
-            link_to(_('Snapshots'), "../foreman_xen/snapshots/#{@host.id}/",
-                    :title => _('Manage machine snapshots'))
+          unless host.compute_resource.nil?
+            if host.compute_resource.type == 'ForemanXen::Xenserver'
+              link_to(_('Snapshots'), "../foreman_xen/snapshots/#{@host.id}/",
+                      :title => _('Manage machine snapshots'))
+            end
           end,
           if host.build
             link_to_if_authorized(


### PR DESCRIPTION
When no compute resources are installed, `NoMethodError: undefined method 'type' for nil:NilClass` will happen otherwise.