### PR TITLE
Fixes #17348

### DIFF
--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -204,8 +204,8 @@ module ForemanXen
         logger.info "create_vm(): builtin_template_name: #{builtin_template_name}"
         vm = custom_template_name != '' ? create_vm_from_custom(args) : create_vm_from_builtin(args)
         vm.set_attribute('name_description', 'Provisioned by Foreman')
-        vm.set_attribute('VCPUs_at_startup', args[:vcpus_max])
         vm.set_attribute('VCPUs_max', args[:vcpus_max])
+        vm.set_attribute('VCPUs_at_startup', args[:vcpus_max])
         vm.reload
         return vm
       rescue => e


### PR DESCRIPTION
This is being caused by setting `vcpus_at_startup` to more than `vcpus_max`. XenServer won't allow this.

Definitely fixed in 6.5, going to test on 7 and update tomorrow (hopefully)

    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|audit] VM.set_VCPUs_at_startup: self = 2a3db339-98bc-d750-8f68-2aa1c207565d (<redacted>); value = 4
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|backtrace] Raised at xapi_vm_helpers.ml:200.30-92 -> xapi_vm.ml:575.41-145 -> rbac.ml:229.16-23
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|backtrace] Raised at rbac.ml:238.10-15 -> server_helpers.ml:79.11-41
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|dispatcher] Server_helpers.exec exception_handler: Got exception INVALID_VALUE: [ VCPU values must satisfy: 0 < VCPUs_at_startup ≤ VCPUs_max; 4 ]
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|dispatcher] Raised at string.ml:150.25-34 -> stringext.ml:108.13-29
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|backtrace] Raised at string.ml:150.25-34 -> stringext.ml:108.13-29
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|xapi] Raised at server_helpers.ml:94.14-15 -> pervasiveext.ml:22.2-9
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|VM.set_VCPUs_at_startup D:1df654d24631|xapi] Raised at pervasiveext.ml:26.22-25 -> pervasiveext.ml:22.2-9
    Dec 21 16:35:19 localhost xapi: [debug||58978701 INET :::80|dispatch:VM.set_VCPUs_at_startup D:76312e8b891a|xapi] Raised at pervasiveext.ml:26.22-25 -> pervasiveext.ml:22.2-9

(ref: http://projects.theforeman.org/issues/17348)