### PR TITLE
Cache Templates, Networks & Storage Pools

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,7 +40,7 @@ Metrics/BlockNesting:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 347
+  Max: 368 
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:
@@ -50,6 +50,14 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 52
+
+# Offense count: 1
+Metrics/ModuleLength:
+  Max: 112
+
+# Offense count: 4
+Metrics/ParameterLists:
+  Max: 6
 
 # Offense count: 4
 Metrics/PerceivedComplexity:

--- a/app/assets/javascripts/compute_resources/xenserver/cache_refresh.js
+++ b/app/assets/javascripts/compute_resources/xenserver/cache_refresh.js
@@ -1,19 +1,19 @@
-function refreshCache(attribute_name, compute_resource_id, on_success) {
+function refreshCache(item, on_success) {
     tfm.tools.showSpinner();
-    url = "/foreman_xen/cache/refresh";
+    attribute_name = $(item).data('attribute')
     data = {
         type: attribute_name,
-        compute_resource_id: compute_resource_id
+        compute_resource_id: $(item).data('compute-resource-id')
     }
     $.ajax({
             type:'post',
-            url: url,
+            url: $(item).data('url'),
             data: data,
             complete: function(){
                 tfm.tools.hideSpinner();
             },
             error: function(){
-                $.jnotify(__("Error refreshing cache for " + attribute_name), 'error', true);
+                notify(__("Error refreshing cache for " + attribute_name), 'error', true);
             },
             success: on_success
         })

--- a/app/assets/javascripts/compute_resources/xenserver/cache_refresh.js
+++ b/app/assets/javascripts/compute_resources/xenserver/cache_refresh.js
@@ -12,9 +12,8 @@ function refreshCache(attribute_name, compute_resource_id, on_success) {
             complete: function(){
                 tfm.tools.hideSpinner();
             },
-            error: function(jqXHR, status, error){
-                $('#scheduler_hint_wrapper').html(Jed.sprintf(__("Error loading scheduler hint filters information: %s"), error));
-                $('#compute_resource_tab a').addClass('tab-error');
+            error: function(){
+                $.jnotify(__("Error refreshing cache for " + attribute_name), 'error', true);
             },
             success: on_success
         })

--- a/app/assets/javascripts/compute_resources/xenserver/cache_refresh.js
+++ b/app/assets/javascripts/compute_resources/xenserver/cache_refresh.js
@@ -1,0 +1,21 @@
+function refreshCache(attribute_name, compute_resource_id, on_success) {
+    tfm.tools.showSpinner();
+    url = "/foreman_xen/cache/refresh";
+    data = {
+        type: attribute_name,
+        compute_resource_id: compute_resource_id
+    }
+    $.ajax({
+            type:'post',
+            url: url,
+            data: data,
+            complete: function(){
+                tfm.tools.hideSpinner();
+            },
+            error: function(jqXHR, status, error){
+                $('#scheduler_hint_wrapper').html(Jed.sprintf(__("Error loading scheduler hint filters information: %s"), error));
+                $('#compute_resource_tab a').addClass('tab-error');
+            },
+            success: on_success
+        })
+}

--- a/app/assets/javascripts/compute_resources/xenserver/populate_fields.js
+++ b/app/assets/javascripts/compute_resources/xenserver/populate_fields.js
@@ -1,5 +1,4 @@
 function xenPopulateNetworks(network_list){
-    console.log("HAHAHAHAHAHAAH");
     $('#host_compute_attributes_VIFs_print').children().remove();
     for (var i = 0; i < network_list.length; i++) {
         network = network_list[i];

--- a/app/assets/javascripts/compute_resources/xenserver/populate_fields.js
+++ b/app/assets/javascripts/compute_resources/xenserver/populate_fields.js
@@ -1,0 +1,33 @@
+function xenPopulateNetworks(network_list){
+    console.log("HAHAHAHAHAHAAH");
+    $('#host_compute_attributes_VIFs_print').children().remove();
+    for (var i = 0; i < network_list.length; i++) {
+        network = network_list[i];
+        $('#host_compute_attributes_VIFs_print').append('<option id=' + network['name'] + '>' + network['name'] + '</option>');
+    }
+}
+
+function xenPopulateStoragePools(results){
+    $('#host_compute_attributes_VBDs_sr_uuid').children().remove();
+    for (var i = 0; i < results.length; i++) {
+        result = results[i];
+        $('#host_compute_attributes_VBDs_sr_uuid').append('<option id=' + result['uuid'] + '>' + result['name'] + '</option>');
+    }
+}
+
+function xenPopulateCustomTemplates(custom_templates){
+    xenPopulateTemplates(custom_templates, '#host_compute_attributes_custom_template_name');
+}
+
+function xenPopulateBuiltinTemplates(builtin_templates){
+    xenPopulateTemplates(builtin_templates, '#host_compute_attributes_builtin_template_name');
+}
+
+function xenPopulateTemplates(results, selector){
+    $(selector).children().remove();
+    $(selector).append('<option>No template</option>');
+    for (var i = 0; i < results.length; i++) {
+        result = results[i];
+        $(selector).append('<option id=' + result['name'] + '>' + result['name'] + '</option>');
+    }
+}

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -1,11 +1,10 @@
 module ForemanXen
   class CacheController < ::ApplicationController
-
-    before_action :get_compute_resource
+    before_action :load_compute_resource
 
     # POST = foreman_xen/cache/refresh
     def refresh
-      type                = params[:type]
+      type = params[:type]
 
       unless cache_attribute_whitelist.include?(type)
         process_error(:error_msg => "Error refreshing cache. #{type} is not a white listed attribute")
@@ -28,8 +27,8 @@ module ForemanXen
       %w(networks hypervisors templates custom_templates builtin_templates storage_pools)
     end
 
-    def get_compute_resource
-      @compute_resource = ComputeResource.find_by_id(params['compute_resource_id'])
+    def load_compute_resource
+      @compute_resource = ComputeResource.find_by(id: params['compute_resource_id'])
     end
   end
 end

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -6,6 +6,11 @@ module ForemanXen
     # POST = foreman_xen/cache/refresh
     def refresh
       type                = params[:type]
+
+      unless cache_attribute_whitelist.include?(type)
+        process_error(:error_msg => "Error refreshing cache. #{type} is not a white listed attribute")
+      end
+
       unless @compute_resource.respond_to?("#{type}!")
         process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource" +
             @compute_resource.name)
@@ -17,6 +22,11 @@ module ForemanXen
     end
 
     private
+
+    # List of methods to permit
+    def cache_attribute_whitelist
+      %w(networks hypervisors templates custom_templates builtin_templates storage_pools)
+    end
 
     def get_compute_resource
       @compute_resource = ComputeResource.find_by_id(params['compute_resource_id'])

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -1,11 +1,11 @@
 module ForemanXen
   class CacheController < ::ApplicationController
 
+    before_action :get_compute_resource
+
     # POST = foreman_xen/cache/refresh
     def refresh
       type                = params[:type]
-      compute_resource_id = params[:compute_resource_id]
-      @compute_resource   = get_compute_resource_by_id(compute_resource_id)
       unless @compute_resource.respond_to?("#{type}!")
         process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource" +
             @compute_resource.name)
@@ -18,8 +18,8 @@ module ForemanXen
 
     private
 
-    def get_compute_resource_by_id(compute_resource_id)
-      ComputeResource.where(:id => compute_resource_id).to_a[0] if compute_resource_id
+    def get_compute_resource
+      @compute_resource = ComputeResource.find_by_id(:params[:compute_resource_id]).first
     end
   end
 end

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -1,0 +1,34 @@
+module ForemanXen
+  class CacheController < ::ApplicationController
+    helper :all
+    skip_before_action :verify_authenticity_token
+
+    # POST = foreman_xen/cache/refresh
+    def refresh
+      type                = params[:type]
+      compute_resource_id = params[:compute_resource_id]
+      @compute_resource   = get_compute_resource_by_id(compute_resource_id)
+      retval = nil
+      if @compute_resource
+        if @compute_resource.respond_to?("#{type}!")
+          retval = @compute_resource.public_send("#{type}!")
+        else
+          process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource #{@compute_resource.name}")
+        end
+      else
+        process_error(:error_msg => "Error retrieving compute resource information")
+      end
+
+      respond_to do |format|
+        format.json  { render :json => retval }
+      end
+
+    end
+
+    private
+
+    def get_compute_resource_by_id(compute_resource_id)
+      ComputeResource.where(:id => compute_resource_id).to_a[0] if compute_resource_id
+    end
+  end
+end

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -19,7 +19,7 @@ module ForemanXen
     private
 
     def get_compute_resource
-      @compute_resource = ComputeResource.find_by_id(:params[:compute_resource_id]).first
+      @compute_resource = ComputeResource.find_by_id(params['compute_resource_id'])
     end
   end
 end

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -1,7 +1,5 @@
 module ForemanXen
   class CacheController < ::ApplicationController
-    helper :all
-    skip_before_action :verify_authenticity_token
 
     # POST = foreman_xen/cache/refresh
     def refresh

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -6,20 +6,13 @@ module ForemanXen
       type                = params[:type]
       compute_resource_id = params[:compute_resource_id]
       @compute_resource   = get_compute_resource_by_id(compute_resource_id)
-      retval = nil
-      if @compute_resource
-        if @compute_resource.respond_to?("#{type}!")
-          retval = @compute_resource.public_send("#{type}!")
-        else
-          process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource" +
-              @compute_resource.name)
-        end
-      else
-        process_error(:error_msg => 'Error retrieving compute resource information')
+      unless @compute_resource.respond_to?("#{type}!")
+        process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource" +
+            @compute_resource.name)
       end
 
       respond_to do |format|
-        format.json { render :json => retval }
+        format.json { render :json => @compute_resource.public_send("#{type}!") }
       end
     end
 

--- a/app/controllers/foreman_xen/cache_controller.rb
+++ b/app/controllers/foreman_xen/cache_controller.rb
@@ -13,16 +13,16 @@ module ForemanXen
         if @compute_resource.respond_to?("#{type}!")
           retval = @compute_resource.public_send("#{type}!")
         else
-          process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource #{@compute_resource.name}")
+          process_error(:error_msg => "Error refreshing cache. Method '#{type}!' not found for compute resource" +
+              @compute_resource.name)
         end
       else
-        process_error(:error_msg => "Error retrieving compute resource information")
+        process_error(:error_msg => 'Error retrieving compute resource information')
       end
 
       respond_to do |format|
-        format.json  { render :json => retval }
+        format.json { render :json => retval }
       end
-
     end
 
     private

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -103,6 +103,6 @@ module XenComputeHelper
   end
 
   def hypervisor_map(compute_resource)
-    compute_resource.available_hypervisors.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
+    compute_resource.available_hypervisors!.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
   end
 end

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -1,7 +1,5 @@
 module XenComputeHelper
 
-  CACHE_PATH = File.exists?(SETTINGS[:puppetvardir]) ? Settings[:puppetvardir] : "/tmp"
-
   def compute_attribute_map(params, compute_resource, new)
     if controller_name == 'hosts'
       attribute_map = hosts_controller_compute_attribute_map(params, compute_resource, new)
@@ -94,47 +92,19 @@ module XenComputeHelper
   end
 
   def builtin_template_map(compute_resource)
-    if(not persisted_map_exists?('builtin_templates'))
-      persist_map('builtin_templates', compute_resource.builtin_templates.map { |t| [t.name, t.name] })
-    end
-    load_map('builtin_templates')
+    compute_resource.builtin_templates.map { |t| [t.name, t.name] }
   end
 
   def custom_template_map(compute_resource)
-    if(not persisted_map_exists?('custom_templates'))
-      persist_map('custom_templates', compute_resource.custom_templates.map { |t| [t.name, t.name] })
-    end
-    load_map('custom_templates')
+    compute_resource.custom_templates.map { |t| [t.name, t.name] }
   end
 
   def storage_pool_map(compute_resource)
-    if(not persisted_map_exists?('storage_pools'))
-      persist_map('storage_pools', compute_resource.storage_pools.map { |item| [item[:display_name], item[:uuid]] })
-    end
-    load_map('storage_pools')
+    compute_resource.storage_pools.map { |item| [item[:display_name], item[:uuid]] }
   end
 
   def hypervisor_map(compute_resource)
-    if(not persisted_map_exists?('hypervisor'))
-      persist_map('hypervisor', compute_resource.available_hypervisors.map { |t| [t.name + " - " + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + "% free mem", t.name] })
-    end
-    load_map('hypervisor')
-  end
-
-  private
-
-  def persist_map(name, map, file="xen_#{name}_map.cache")
-    File.open(File.join(CACHE_PATH, file),'w') do |m|
-      m.write map.to_yaml
-    end
-  end
-
-  def load_map(name, file="xen_#{name}_map.cache")
-    YAML.load_file(File.join(CACHE_PATH, file))
-  end
-
-  def persisted_map_exists?(name, file="xen_#{name}_map.cache")
-    File.exists?(File.join(CACHE_PATH, file))
+      compute_resource.available_hypervisors.map { |t| [t.name + " - " + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + "% free mem", t.name] }
   end
 
 end

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -90,19 +90,19 @@ module XenComputeHelper
     attribute_map
   end
 
-  def builtin_template_map(compute_resource)
+  def xen_builtin_template_map(compute_resource)
     compute_resource.builtin_templates.map { |t| [t.name, t.name] }
   end
 
-  def custom_template_map(compute_resource)
+  def xen_custom_template_map(compute_resource)
     compute_resource.custom_templates.map { |t| [t.name, t.name] }
   end
 
-  def storage_pool_map(compute_resource)
+  def xen_storage_pool_map(compute_resource)
     compute_resource.storage_pools.map { |item| [item[:display_name], item[:uuid]] }
   end
 
-  def hypervisor_map(compute_resource)
+  def xen_hypervisor_map(compute_resource)
     compute_resource.available_hypervisors!.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
   end
 end

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -103,10 +103,15 @@ module XenComputeHelper
   end
 
   def xen_hypervisor_map(compute_resource)
-    compute_resource.available_hypervisors!.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
+    compute_resource.available_hypervisors!.map do |t|
+      [t.name + ' - ' + (
+        t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100
+      ).round(2).to_s + '% free mem', t.name]
+    end
   end
 
-  def selectable_f_with_cache_invalidation(f, attr, array, select_options = {}, html_options = {}, input_group_options = {})
+  def selectable_f_with_cache_invalidation(f, attr, array,
+                                           select_options = {}, html_options = {}, input_group_options = {})
     unless html_options.key?('input_group_btn')
       html_options[:input_group_btn] = link_to_function(
         icon_text('refresh'),

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -1,5 +1,4 @@
 module XenComputeHelper
-
   def compute_attribute_map(params, compute_resource, new)
     if controller_name == 'hosts'
       attribute_map = hosts_controller_compute_attribute_map(params, compute_resource, new)
@@ -104,7 +103,9 @@ module XenComputeHelper
   end
 
   def hypervisor_map(compute_resource)
-      compute_resource.available_hypervisors.map { |t| [t.name + " - " + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + "% free mem", t.name] }
+    compute_resource.available_hypervisors.map do |t|
+      [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem',
+       t.name]
+    end
   end
-
 end

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -106,17 +106,19 @@ module XenComputeHelper
     compute_resource.available_hypervisors!.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
   end
 
-  def selectable_f_with_cache_invalidation(f, attr, array, select_options = {}, html_options = {},  input_group_options = {})
-    unless html_options.has_key?('input_group_btn')
-      html_options[:input_group_btn] = link_to_function(icon_text('refresh'), "refreshCache(this, #{input_group_options[:callback]})", {
-          :class => 'btn btn-primary',
-          :title => _(input_group_options[:title]),
-          :data => {
-              :url => input_group_options[:url],
-              :compute_resource_id => input_group_options[:computer_resource_id],
-              :attribute => input_group_options[:attribute]
-          }
-      })
+  def selectable_f_with_cache_invalidation(f, attr, array, select_options = {}, html_options = {}, input_group_options = {})
+    unless html_options.key?('input_group_btn')
+      html_options[:input_group_btn] = link_to_function(
+        icon_text('refresh'),
+        "refreshCache(this, #{input_group_options[:callback]})",
+        :class => 'btn btn-primary',
+        :title => _(input_group_options[:title]),
+        :data  => {
+          :url                 => input_group_options[:url],
+          :compute_resource_id => input_group_options[:computer_resource_id],
+          :attribute           => input_group_options[:attribute]
+        }
+      )
     end
     selectable_f(f, attr, array, select_options, html_options)
   end

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -105,4 +105,19 @@ module XenComputeHelper
   def xen_hypervisor_map(compute_resource)
     compute_resource.available_hypervisors!.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
   end
+
+  def selectable_f_with_cache_invalidation(f, attr, array, select_options = {}, html_options = {},  input_group_options = {})
+    unless html_options.has_key?('input_group_btn')
+      html_options[:input_group_btn] = link_to_function(icon_text('refresh'), "refreshCache(this, #{input_group_options[:callback]})", {
+          :class => 'btn btn-primary',
+          :title => _(input_group_options[:title]),
+          :data => {
+              :url => input_group_options[:url],
+              :compute_resource_id => input_group_options[:computer_resource_id],
+              :attribute => input_group_options[:attribute]
+          }
+      })
+    end
+    selectable_f(f, attr, array, select_options, html_options)
+  end
 end

--- a/app/helpers/xen_compute_helper.rb
+++ b/app/helpers/xen_compute_helper.rb
@@ -103,9 +103,6 @@ module XenComputeHelper
   end
 
   def hypervisor_map(compute_resource)
-    compute_resource.available_hypervisors.map do |t|
-      [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem',
-       t.name]
-    end
+    compute_resource.available_hypervisors.map { |t| [t.name + ' - ' + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + '% free mem', t.name] }
   end
 end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -2,8 +2,6 @@ module ForemanXen
   class Xenserver < ComputeResource
     validates :url, :user, :password, :presence => true
 
-    CACHE_PATH = "/tmp"
-
     def provided_attributes
       super.merge(
         :uuid => :reference,

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -65,7 +65,7 @@ module ForemanXen
 
     def available_hypervisors!
       store_in_cache('available_hypervisors') do
-        hosts = client.hosts rescue []
+        hosts = client.hosts
         hosts.sort_by(&:name)
       end
     end
@@ -85,7 +85,7 @@ module ForemanXen
     def storage_pools!
       store_in_cache('storage_pools') do
         results = []
-        storages = client.storage_repositories.select { |sr| sr.type != 'udev' && sr.type != 'iso' } rescue []
+        storages = client.storage_repositories.select { |sr| sr.type != 'udev' && sr.type != 'iso' }
         storages.each do |sr|
           subresults = {}
           found      = false
@@ -98,7 +98,7 @@ module ForemanXen
             subresults[:uuid]         = sr.uuid
             break
           end
-          if not found
+          unless found
             subresults[:name]         = sr.name
             subresults[:display_name] = sr.name
             subresults[:uuid]         = sr.uuid
@@ -121,7 +121,7 @@ module ForemanXen
 
     def networks!
       store_in_cache('networks') do
-        client.networks.sort_by(&:name) rescue []
+        client.networks.sort_by(&:name)
       end
     end
 
@@ -418,7 +418,7 @@ module ForemanXen
     end
 
     def get_templates(templates)
-      tmps = templates.select { |t| !t.is_a_snapshot } rescue []
+      tmps = templates.select { |t| !t.is_a_snapshot }
       tmps.sort_by(&:name)
     end
 

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -60,11 +60,11 @@ module ForemanXen
     end
 
     def available_hypervisors
-      self.read_from_cache('available_hypervisors', 'available_hypervisors!')
+      read_from_cache('available_hypervisors', 'available_hypervisors!')
     end
 
     def available_hypervisors!
-      self.store_in_cache('available_hypervisors') do
+      store_in_cache('available_hypervisors') do
         hosts = client.hosts rescue []
         hosts.sort_by(&:name)
       end
@@ -79,11 +79,11 @@ module ForemanXen
     end
 
     def storage_pools
-      self.read_from_cache('storage_pools', 'storage_pools!')
+      read_from_cache('storage_pools', 'storage_pools!')
     end
 
     def storage_pools!
-      self.store_in_cache('storage_pools') do
+      store_in_cache('storage_pools') do
         results = []
         storages = client.storage_repositories.select { |sr| sr.type != 'udev' && sr.type != 'iso' } rescue []
         storages.each do |sr|
@@ -116,41 +116,41 @@ module ForemanXen
     end
 
     def networks
-      self.read_from_cache('networks', 'networks!')
+      read_from_cache('networks', 'networks!')
     end
 
     def networks!
-      self.store_in_cache('networks') do
+      store_in_cache('networks') do
         client.networks.sort_by(&:name) rescue []
       end
     end
 
     def templates
-      self.read_from_cache('templates', 'templates!')
+      read_from_cache('templates', 'templates!')
     end
 
     def templates!
-      self.store_in_cache('templates') do
+      store_in_cache('templates') do
         client.servers.templates.sort_by(&:name)
       end
     end
 
     def custom_templates
-      self.read_from_cache('custom_templates', 'custom_templates!')
+      read_from_cache('custom_templates', 'custom_templates!')
     end
 
     def custom_templates!
-      self.store_in_cache('custom_templates') do
+      store_in_cache('custom_templates') do
         get_templates(client.servers.custom_templates)
       end
     end
 
     def builtin_templates
-      self.read_from_cache('builtin_templates', 'builtin_templates!')
+      read_from_cache('builtin_templates', 'builtin_templates!')
     end
 
     def builtin_templates!
-      self.store_in_cache('builtin_templates') do
+      store_in_cache('builtin_templates') do
         get_templates(client.servers.builtin_templates)
       end
     end
@@ -387,21 +387,6 @@ module ForemanXen
       super.merge({})
     end
 
-    def read_from_cache(key, fallback)
-      value = Rails.cache.fetch(cache_key + key) { public_send(fallback) }
-      value
-    end
-
-    def store_in_cache(key)
-      value = yield
-      Rails.cache.write(cache_key + key, value)
-      value
-    end
-
-    def cache_key
-      "computeresource_#{id}/"
-    end
-
     private
 
     def create_network(vm, args)
@@ -440,6 +425,21 @@ module ForemanXen
     def get_hypervisor_host(args)
       return client.hosts.first unless args[:hypervisor_host] != ''
       client.hosts.find { |host| host.name == args[:hypervisor_host] }
+    end
+
+    def read_from_cache(key, fallback)
+      value = Rails.cache.fetch(cache_key + key) { public_send(fallback) }
+      value
+    end
+
+    def store_in_cache(key)
+      value = yield
+      Rails.cache.write(cache_key + key, value)
+      value
+    end
+
+    def cache_key
+      "computeresource_#{id}/"
     end
   end
 end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -450,6 +450,5 @@ module ForemanXen
       return client.hosts.first unless args[:hypervisor_host] != ''
       client.hosts.find { |host| host.name == args[:hypervisor_host] }
     end
-
   end
 end

--- a/app/views/compute_resources_vms/form/_hypervisors.html.erb
+++ b/app/views/compute_resources_vms/form/_hypervisors.html.erb
@@ -1,5 +1,12 @@
 <div id='templates' class=''>
   <div class="form-group">
-    <%= selectable_f f, :hypervisor_host, [[_("Automatic allocation"), ""]] + xen_hypervisor_map(compute_resource), {}, :class => 'form-control span2', :disabled => (controller_name != 'hosts'), :label => 'Hypervisor' %>
+    <%= selectable_f f, :hypervisor_host,
+                     [[_("Automatic allocation"), ""]] + xen_hypervisor_map(compute_resource),
+                     {},
+                     { :class => 'form-control span2',
+                       :disabled => (controller_name != 'hosts'),
+                       :label => 'Hypervisor'
+                     }
+    %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_hypervisors.html.erb
+++ b/app/views/compute_resources_vms/form/_hypervisors.html.erb
@@ -1,5 +1,5 @@
 <div id='templates' class=''>
   <div class="form-group">
-    <%= selectable_f f, :hypervisor_host, [[_("Automatic allocation"), ""]] + hypervisor_map(compute_resource), {}, :class => 'form-control span2', :disabled => (controller_name != 'hosts'), :label => 'Hypervisor' %>
+    <%= selectable_f f, :hypervisor_host, [[_("Automatic allocation"), ""]] + xen_hypervisor_map(compute_resource), {}, :class => 'form-control span2', :disabled => (controller_name != 'hosts'), :label => 'Hypervisor' %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_hypervisors.html.erb
+++ b/app/views/compute_resources_vms/form/_hypervisors.html.erb
@@ -1,5 +1,5 @@
 <div id='templates' class=''>
   <div class="form-group">
-    <%= selectable_f f, :hypervisor_host, [[_("Automatic allocation"), ""]] + compute_resource.available_hypervisors.map { |t| [t.name + " - " + (t.metrics.memory_free.to_f / t.metrics.memory_total.to_f * 100).round(2).to_s + "% free mem", t.name] }, {}, :class => 'form-control span2', :disabled => (controller_name != 'hosts'), :label => 'Hypervisor' %>
+    <%= selectable_f f, :hypervisor_host, [[_("Automatic allocation"), ""]] + hypervisor_map(compute_resource), {}, :class => 'form-control span2', :disabled => (controller_name != 'hosts'), :label => 'Hypervisor' %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_network.html.erb
+++ b/app/views/compute_resources_vms/form/_network.html.erb
@@ -1,21 +1,19 @@
 <div class="fields">
   <div id='nat' class=''>
-    <%= selectable_f f, :print,
+    <%= selectable_f_with_cache_invalidation f, :print,
                      compute_resource.networks.map(&:name),
                      {  :include_blank => compute_resource.networks.any? ? false : _('No networks'),
                         :selected      => attribute_map[:network_selected]
                      },
-                     {  :class           => 'span2',
-                        :label           => _('Network'),
-                        :input_group_btn => link_to_function(icon_text('refresh'), 'refreshCache(this, xenPopulateNetworks)', {
-                          :class => 'btn btn-primary',
-                          :title => _('Refresh the available networks.'),
-                          :data => {
-                            :url => '/foreman_xen/cache/refresh',
-                            :compute_resource_id => compute_resource.id,
-                            :attribute => 'networks'
-                          }
-                        })
+                     {  :class         => 'span2',
+                        :label         => _('Network')
+                     },
+                     {
+                         :callback               => 'xenPopulateNetworks',
+                         :title                  => 'Refresh available networks',
+                         :url                    => '/foreman_xen/cache/refresh',
+                         :computer_resource_id   => compute_resource.id,
+                         :attribute              => 'networks'
                      }
     %>
   </div>

--- a/app/views/compute_resources_vms/form/_network.html.erb
+++ b/app/views/compute_resources_vms/form/_network.html.erb
@@ -1,12 +1,22 @@
-<div class="fields">
-  <%
-     nat = compute_resource.networks
-  -%>
+<script>
+    populateNetworks = function(results){
+        $('#host_compute_attributes_VIFs_print').children().remove();
+        for (var i = 0; i < results.length; i++) {
+            result = results[i];
+            $('#host_compute_attributes_VIFs_print').append('<option id=' + result['name'] + '>' + result['name'] + '</option>');
+        }
+    }
+</script>
 
+<div class="fields">
   <div id='nat' class=''>
-    <%= selectable_f f, :print, nat.map(&:name),
-                     { :include_blank => nat.any? ? false : _("No networks"),
+    <%= selectable_f f, :print, compute_resource.networks.map(&:name),
+                     { :include_blank => compute_resource.networks.any? ? false : _("No networks"),
                        :selected      => attribute_map[:network_selected] },
-                     { :class => "span2", :label => _("Network") } %>
+                     { :class           => "span2",
+                       :label           => _("Network"),
+                       :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('networks', #{compute_resource.id}, populateNetworks)", :class => 'btn btn-primary',
+                                                           :title => _('Refresh the available networks.')) }
+    %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_network.html.erb
+++ b/app/views/compute_resources_vms/form/_network.html.erb
@@ -1,22 +1,22 @@
-<script>
-    populateNetworks = function(results){
-        $('#host_compute_attributes_VIFs_print').children().remove();
-        for (var i = 0; i < results.length; i++) {
-            result = results[i];
-            $('#host_compute_attributes_VIFs_print').append('<option id=' + result['name'] + '>' + result['name'] + '</option>');
-        }
-    }
-</script>
-
 <div class="fields">
   <div id='nat' class=''>
-    <%= selectable_f f, :print, compute_resource.networks.map(&:name),
-                     { :include_blank => compute_resource.networks.any? ? false : _("No networks"),
-                       :selected      => attribute_map[:network_selected] },
-                     { :class           => "span2",
-                       :label           => _("Network"),
-                       :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('networks', #{compute_resource.id}, populateNetworks)", :class => 'btn btn-primary',
-                                                           :title => _('Refresh the available networks.')) }
+    <%= selectable_f f, :print,
+                     compute_resource.networks.map(&:name),
+                     {  :include_blank => compute_resource.networks.any? ? false : _('No networks'),
+                        :selected      => attribute_map[:network_selected]
+                     },
+                     {  :class           => 'span2',
+                        :label           => _('Network'),
+                        :input_group_btn => link_to_function(icon_text('refresh'), 'refreshCache(this, xenPopulateNetworks)', {
+                          :class => 'btn btn-primary',
+                          :title => _('Refresh the available networks.'),
+                          :data => {
+                            :url => '/foreman_xen/cache/refresh',
+                            :compute_resource_id => compute_resource.id,
+                            :attribute => 'networks'
+                          }
+                        })
+                     }
     %>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -23,7 +23,7 @@
     <div class="form-group">
       <%= selectable_f(f,
                        :custom_template_name,
-                       [[_("No template"), ""]] + custom_template_map(compute_resource),
+                       [[_("No template"), ""]] + xen_custom_template_map(compute_resource),
                        { :selected => attribute_map[:template_selected_custom] },
                        {:class => 'form-control span2',
                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('custom_templates', #{compute_resource.id})", :class => 'btn btn-primary',
@@ -37,7 +37,7 @@
     <div class="form-group ">
       <%= selectable_f(f,
                        :builtin_template_name,
-                       [[_("No template"), ""]] + builtin_template_map(compute_resource),
+                       [[_("No template"), ""]] + xen_builtin_template_map(compute_resource),
                        { :selected => attribute_map[:template_selected_builtin] },
                        { :class => 'form-control span2',
                          :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('builtin_templates', #{compute_resource.id})", :class => 'btn btn-primary',

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -1,50 +1,41 @@
-<script>
-
-
-  populateCustomTemplates = function(results){
-      populateTemplates(results, '#host_compute_attributes_custom_template_name');
-  }
-
-  populateBuiltinTemplates = function(results){
-      populateTemplates(results, '#host_compute_attributes_builtin_template_name');
-  }
-
-  function populateTemplates(results, selector){
-      $(selector).children().remove();
-      for (var i = 0; i < results.length; i++) {
-          result = results[i];
-          $(selector).append('<option id=' + result['name'] + '>' + result['name'] + '</option>');
-      }
-  }
-</script>
-
 <div class="fields">
   <div id='templates' class=''>
     <div class="form-group">
-      <%= selectable_f(f,
+      <%= selectable_f f,
                        :custom_template_name,
                        [[_("No template"), ""]] + xen_custom_template_map(compute_resource),
                        { :selected => attribute_map[:template_selected_custom] },
-                       {:class => 'form-control span2',
-                        :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('custom_templates', #{compute_resource.id})", :class => 'btn btn-primary',
-                                                             :title => _('Refresh available custom templates.')),
-                        :label => 'Custom Template'
+                       { :class => 'form-control span2',
+                         :label => 'Custom Template',
+                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache(this, xenPopulateCustomTemplates)",
+                           :class => 'btn btn-primary',
+                           :title => _('Refresh available custom templates.'),
+                           :data => {
+                             :url => "/foreman_xen/cache/refresh",
+                             :compute_resource_id => compute_resource.id,
+                             :attribute => 'custom_templates'
+                           }
+                         )
                        }
-          )
       %>
     </div>
 
     <div class="form-group ">
-      <%= selectable_f(f,
-                       :builtin_template_name,
+      <%= selectable_f f, :builtin_template_name,
                        [[_("No template"), ""]] + xen_builtin_template_map(compute_resource),
                        { :selected => attribute_map[:template_selected_builtin] },
                        { :class => 'form-control span2',
-                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('builtin_templates', #{compute_resource.id})", :class => 'btn btn-primary',
-                                                              :title => _('Refresh available builtin templates.')),
-                         :label => 'Builtin Template'
+                         :label => 'Builtin Template',
+                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache(this, xenPopulateBuiltinTemplates)",
+                           :class => 'btn btn-primary',
+                           :title => _('Refresh available builtin templates.'),
+                           :data => {
+                             :url => "/foreman_xen/cache/refresh",
+                             :compute_resource_id => compute_resource.id,
+                             :attribute => 'builtin_templates'
+                           }
+                         )
                        }
-          )
       %>
     </div>
   </div>

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -21,7 +21,7 @@
     <div class="form-group ">
       <%= selectable_f_with_cache_invalidation f,
                                                :builtin_template_name,
-                                               [[_("No template"), ""]] + xen_custom_template_map(compute_resource),
+                                               [[_("No template"), ""]] + xen_builtin_template_map(compute_resource),
                                                { :selected => attribute_map[:template_selected_builtin] },
                                                { :class => 'form-control span2',
                                                  :label => 'Builtin Template'

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -1,11 +1,51 @@
+<script>
+
+
+  populateCustomTemplates = function(results){
+      populateTemplates(results, '#host_compute_attributes_custom_template_name');
+  }
+
+  populateBuiltinTemplates = function(results){
+      populateTemplates(results, '#host_compute_attributes_builtin_template_name');
+  }
+
+  function populateTemplates(results, selector){
+      $(selector).children().remove();
+      for (var i = 0; i < results.length; i++) {
+          result = results[i];
+          $(selector).append('<option id=' + result['name'] + '>' + result['name'] + '</option>');
+      }
+  }
+</script>
+
 <div class="fields">
   <div id='templates' class=''>
     <div class="form-group">
-      <%= selectable_f f, :custom_template_name, [[_("No template"), ""]] + custom_template_map(compute_resource), { :selected => attribute_map[:template_selected_custom] }, :class => 'form-control span2', :label => 'Custom Template' %>
+      <%= selectable_f(f,
+                       :custom_template_name,
+                       [[_("No template"), ""]] + custom_template_map(compute_resource),
+                       { :selected => attribute_map[:template_selected_custom] },
+                       {:class => 'form-control span2',
+                        :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('custom_templates', #{compute_resource.id})", :class => 'btn btn-primary',
+                                                             :title => _('Refresh available custom templates.')),
+                        :label => 'Custom Template'
+                       }
+          )
+      %>
     </div>
 
     <div class="form-group ">
-      <%= selectable_f f, :builtin_template_name, [[_("No template"), ""]] + builtin_template_map(compute_resource), { :selected => attribute_map[:template_selected_builtin] }, :class => 'form-control span2', :label => 'Builtin Template' %>
+      <%= selectable_f(f,
+                       :builtin_template_name,
+                       [[_("No template"), ""]] + builtin_template_map(compute_resource),
+                       { :selected => attribute_map[:template_selected_builtin] },
+                       { :class => 'form-control span2',
+                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('builtin_templates', #{compute_resource.id})", :class => 'btn btn-primary',
+                                                              :title => _('Refresh available builtin templates.')),
+                         :label => 'Builtin Template'
+                       }
+          )
+      %>
     </div>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -1,11 +1,11 @@
 <div class="fields">
   <div id='templates' class=''>
     <div class="form-group">
-      <%= selectable_f f, :custom_template_name, [[_("No template"), ""]] + compute_resource.custom_templates.map { |t| [t.name, t.name] }, { :selected => attribute_map[:template_selected_custom] }, :class => 'form-control span2', :label => 'Custom Template' %>
+      <%= selectable_f f, :custom_template_name, [[_("No template"), ""]] + custom_template_map(compute_resource), { :selected => attribute_map[:template_selected_custom] }, :class => 'form-control span2', :label => 'Custom Template' %>
     </div>
 
     <div class="form-group ">
-      <%= selectable_f f, :builtin_template_name, [[_("No template"), ""]] + compute_resource.builtin_templates.map { |t| [t.name, t.name] }, { :selected => attribute_map[:template_selected_builtin] }, :class => 'form-control span2', :label => 'Builtin Template' %>
+      <%= selectable_f f, :builtin_template_name, [[_("No template"), ""]] + builtin_template_map(compute_resource), { :selected => attribute_map[:template_selected_builtin] }, :class => 'form-control span2', :label => 'Builtin Template' %>
     </div>
   </div>
 </div>

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -1,41 +1,37 @@
 <div class="fields">
   <div id='templates' class=''>
     <div class="form-group">
-      <%= selectable_f f,
+      <%= selectable_f_with_cache_invalidation f,
                        :custom_template_name,
                        [[_("No template"), ""]] + xen_custom_template_map(compute_resource),
                        { :selected => attribute_map[:template_selected_custom] },
                        { :class => 'form-control span2',
-                         :label => 'Custom Template',
-                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache(this, xenPopulateCustomTemplates)",
-                           :class => 'btn btn-primary',
-                           :title => _('Refresh available custom templates.'),
-                           :data => {
-                             :url => "/foreman_xen/cache/refresh",
-                             :compute_resource_id => compute_resource.id,
-                             :attribute => 'custom_templates'
-                           }
-                         )
+                         :label => 'Custom Template'
+                       },
+                       {
+                         :callback               => 'xenPopulateCustomTemplates',
+                         :title                  => 'Refresh available custom templates',
+                         :url                    => '/foreman_xen/cache/refresh',
+                         :computer_resource_id   => compute_resource.id,
+                         :attribute              => 'custom_templates'
                        }
       %>
     </div>
 
     <div class="form-group ">
-      <%= selectable_f f, :builtin_template_name,
-                       [[_("No template"), ""]] + xen_builtin_template_map(compute_resource),
-                       { :selected => attribute_map[:template_selected_builtin] },
-                       { :class => 'form-control span2',
-                         :label => 'Builtin Template',
-                         :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache(this, xenPopulateBuiltinTemplates)",
-                           :class => 'btn btn-primary',
-                           :title => _('Refresh available builtin templates.'),
-                           :data => {
-                             :url => "/foreman_xen/cache/refresh",
-                             :compute_resource_id => compute_resource.id,
-                             :attribute => 'builtin_templates'
-                           }
-                         )
-                       }
+      <%= selectable_f_with_cache_invalidation f,
+                                               :builtin_template_name,
+                                               [[_("No template"), ""]] + xen_custom_template_map(compute_resource),
+                                               { :selected => attribute_map[:template_selected_builtin] },
+                                               { :class => 'form-control span2',
+                                                 :label => 'Builtin Template'
+                                               },
+                                               {
+                                                   :callback               => 'xenPopulateBuiltinTemplates',
+                                                   :title                  => 'Refresh available builtin templates',                                                  :url                    => '/foreman_xen/cache/refresh',
+                                                   :computer_resource_id   => compute_resource.id,
+                                                   :attribute              => 'builtin_templates'
+                                               }
       %>
     </div>
   </div>

--- a/app/views/compute_resources_vms/form/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/_volume.html.erb
@@ -1,6 +1,6 @@
 <div class="fields">
 
-  <%= selectable_f f, :sr_uuid, compute_resource.storage_pools.map { |item| [item[:display_name], item[:uuid]] }, { :selected => attribute_map[:volume_selected] }, :class => "span2", :label => _("Storage Repository") %>
+  <%= selectable_f f, :sr_uuid, storage_pool_map(compute_resource), { :selected => attribute_map[:volume_selected] }, :class => "span2", :label => _("Storage Repository") %>
 
   <%= text_f f, :physical_size, :class => "input-mini", :label => _("Size (GB)"), :value => attribute_map[:volume_size] %>
 </div>

--- a/app/views/compute_resources_vms/form/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/_volume.html.erb
@@ -1,27 +1,19 @@
-<script>
-    populateStoragePools = function(results){
-        $('#host_compute_attributes_VBDs_sr_uuid').children().remove();
-        for (var i = 0; i < results.length; i++) {
-            result = results[i];
-            $('#host_compute_attributes_VBDs_sr_uuid').append('<option id=' + result['uuid'] + '>' + result['name'] + '</option>');
-        }
-    }
-</script>
-
 <div class="fields">
-
-  <%= selectable_f(
-          f,
-          :sr_uuid,
-          xen_storage_pool_map(compute_resource),
-          { :selected => attribute_map[:volume_selected] },
-          {
-              :class => "span2",
-              :label => _("Storage Repository"),
-              :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('storage_pools', #{compute_resource.id})", :class => 'btn btn-primary',
-                                                   :title => _('Refresh available storage repositories')),
-          }
-      )
+  <%= selectable_f f, :sr_uuid,
+                   xen_storage_pool_map(compute_resource),
+                   { :selected => attribute_map[:volume_selected] },
+                   { :class => "span2",
+                     :label => _("Storage Repository"),
+                     :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache(this, xenPopulateStoragePools)",
+                       :class => 'btn btn-primary',
+                       :title => _('Refresh available storage repositories'),
+                       :data => {
+                         :url => "/foreman_xen/cache/refresh",
+                         :compute_resource_id => compute_resource.id,
+                         :attribute => 'storage_pools'
+                       }
+                     )
+                   }
   %>
 
   <%= text_f f, :physical_size, :class => "input-mini", :label => _("Size (GB)"), :value => attribute_map[:volume_size] %>

--- a/app/views/compute_resources_vms/form/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/_volume.html.erb
@@ -1,19 +1,17 @@
 <div class="fields">
-  <%= selectable_f f, :sr_uuid,
-                   xen_storage_pool_map(compute_resource),
-                   { :selected => attribute_map[:volume_selected] },
-                   { :class => "span2",
-                     :label => _("Storage Repository"),
-                     :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache(this, xenPopulateStoragePools)",
-                       :class => 'btn btn-primary',
-                       :title => _('Refresh available storage repositories'),
-                       :data => {
-                         :url => "/foreman_xen/cache/refresh",
-                         :compute_resource_id => compute_resource.id,
-                         :attribute => 'storage_pools'
-                       }
-                     )
-                   }
+  <%= selectable_f_with_cache_invalidation f, :sr_uuid,
+        xen_storage_pool_map(compute_resource),
+        { :selected => attribute_map[:volume_selected] },
+        { :class => "span2",
+         :label => _("Storage Repository"),
+        },
+        {
+           :callback               => 'xenPopulateStoragePools',
+           :title                  => 'Refresh available storage repositories',
+           :url                    => '/foreman_xen/cache/refresh',
+           :computer_resource_id   => compute_resource.id,
+           :attribute              => 'storage_pools'
+        }
   %>
 
   <%= text_f f, :physical_size, :class => "input-mini", :label => _("Size (GB)"), :value => attribute_map[:volume_size] %>

--- a/app/views/compute_resources_vms/form/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/_volume.html.erb
@@ -13,7 +13,7 @@
   <%= selectable_f(
           f,
           :sr_uuid,
-          storage_pool_map(compute_resource),
+          xen_storage_pool_map(compute_resource),
           { :selected => attribute_map[:volume_selected] },
           {
               :class => "span2",

--- a/app/views/compute_resources_vms/form/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/_volume.html.erb
@@ -1,6 +1,28 @@
+<script>
+    populateStoragePools = function(results){
+        $('#host_compute_attributes_VBDs_sr_uuid').children().remove();
+        for (var i = 0; i < results.length; i++) {
+            result = results[i];
+            $('#host_compute_attributes_VBDs_sr_uuid').append('<option id=' + result['uuid'] + '>' + result['name'] + '</option>');
+        }
+    }
+</script>
+
 <div class="fields">
 
-  <%= selectable_f f, :sr_uuid, storage_pool_map(compute_resource), { :selected => attribute_map[:volume_selected] }, :class => "span2", :label => _("Storage Repository") %>
+  <%= selectable_f(
+          f,
+          :sr_uuid,
+          storage_pool_map(compute_resource),
+          { :selected => attribute_map[:volume_selected] },
+          {
+              :class => "span2",
+              :label => _("Storage Repository"),
+              :input_group_btn => link_to_function(icon_text('refresh'), "refreshCache('storage_pools', #{compute_resource.id})", :class => 'btn btn-primary',
+                                                   :title => _('Refresh available storage repositories')),
+          }
+      )
+  %>
 
   <%= text_f f, :physical_size, :class => "input-mini", :label => _("Size (GB)"), :value => attribute_map[:volume_size] %>
 </div>

--- a/app/views/compute_resources_vms/form/xenserver/_base.html.erb
+++ b/app/views/compute_resources_vms/form/xenserver/_base.html.erb
@@ -191,3 +191,5 @@
         }
     })
 </script>
+
+<%= compute_specific_js(compute_resource, 'cache_refresh') %>

--- a/app/views/compute_resources_vms/form/xenserver/_base.html.erb
+++ b/app/views/compute_resources_vms/form/xenserver/_base.html.erb
@@ -193,3 +193,4 @@
 </script>
 
 <%= compute_specific_js(compute_resource, 'cache_refresh') %>
+<%= compute_specific_js(compute_resource, 'populate_fields') %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,2 @@
 Rails.application.config.assets.precompile += %w(compute_resources/xenserver/cache_refresh.js)
+Rails.application.config.assets.precompile += %w(compute_resources/xenserver/populate_fields.js)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( compute_resources/xenserver/cache_refresh.js )

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w( compute_resources/xenserver/cache_refresh.js )
+Rails.application.config.assets.precompile += %w(compute_resources/xenserver/cache_refresh.js)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,2 +1,0 @@
-Rails.application.config.assets.precompile += %w(compute_resources/xenserver/cache_refresh.js)
-Rails.application.config.assets.precompile += %w(compute_resources/xenserver/populate_fields.js)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
     match 'snapshots/:id/delete/:ref', :to => 'snapshots#destroy', :via => 'get'
 
     match 'snapshots/:id/create', :to => 'snapshots#create', :via => 'post'
+
+    match 'cache/refresh', :to => 'cache#refresh', :via => 'post'
   end
 end

--- a/lib/foreman_xen/engine.rb
+++ b/lib/foreman_xen/engine.rb
@@ -23,11 +23,11 @@ module ForemanXen
     end
 
     assets_to_precompile =
-        Dir.chdir(root) do
-          Dir['app/assets/javascripts/**/*', 'app/assets/stylesheets/**/*'].map do |f|
-            f.split(File::SEPARATOR, 4).last
-          end
+      Dir.chdir(root) do
+        Dir['app/assets/javascripts/**/*', 'app/assets/stylesheets/**/*'].map do |f|
+          f.split(File::SEPARATOR, 4).last
         end
+      end
     initializer 'foreman_xen.assets.precompile' do |app|
       app.config.assets.precompile += assets_to_precompile
     end
@@ -35,7 +35,6 @@ module ForemanXen
     initializer 'foreman_xen.configure_assets', group: :assets do
       SETTINGS[:foreman_xen] = { assets: { precompile: assets_to_precompile } }
     end
-
 
     config.to_prepare do
       begin

--- a/lib/foreman_xen/engine.rb
+++ b/lib/foreman_xen/engine.rb
@@ -22,6 +22,21 @@ module ForemanXen
       end
     end
 
+    assets_to_precompile =
+        Dir.chdir(root) do
+          Dir['app/assets/javascripts/**/*', 'app/assets/stylesheets/**/*'].map do |f|
+            f.split(File::SEPARATOR, 4).last
+          end
+        end
+    initializer 'foreman_xen.assets.precompile' do |app|
+      app.config.assets.precompile += assets_to_precompile
+    end
+
+    initializer 'foreman_xen.configure_assets', group: :assets do
+      SETTINGS[:foreman_xen] = { assets: { precompile: assets_to_precompile } }
+    end
+
+
     config.to_prepare do
       begin
         # extend fog xen server and image models.


### PR DESCRIPTION
Hey All.

I've always had complaints from my team about the amount of time it takes for Foreman to load the XenServer UI in comparison to plugins that use less API calls such as the VMWare one.

As a solution, I've used Rails built in caching to cache the API call response and modified the UI to allow the user to refresh the list at deploy time. Both builtin and custom templates, networks and storage pools are cached - the hypervisor data was not as the UI relies on the metrics association which doesn't survive caching.