### PR TITLE
Make guest tools installation works for XenServer > 7.0 

### DIFF
--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -315,7 +315,7 @@ module ForemanXen
 
       if args[:xstools] == '1'
         # Add xs-tools ISO to newly created VMs
-        dvd_vdi = client.vdis.find { |isovdi| isovdi.name == 'xs-tools.iso' }
+        dvd_vdi = client.vdis.find { |isovdi| isovdi.name == 'xs-tools.iso' or isovdi.name == 'guest-tools.iso' }
         vbdconnectcd = {
           'vdi'                  => dvd_vdi,
           'vm'                   => vm.reference,


### PR DESCRIPTION
Since XenServer 7.0 the guest additions CD was renamed from xs-tools.iso to guest-tools.iso. This patch allows The Foreman to find the right ISO in VDI's collection.