### PR TITLE
Make snapshot listing work

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Lint/UselessAssignment:
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 65
+  Max: 67
 
 # Offense count: 2
 # Configuration parameters: CountBlocks.

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -168,7 +168,7 @@ module ForemanXen
       end
       retval = []
       tmps.each do |snapshot|
-        retval << snapshot if vm.snapshots.include?(snapshot.reference)
+	retval << snapshot if snapshot.snapshot_metadata.include?(vm.uuid)
       end
       retval
     end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -315,7 +315,7 @@ module ForemanXen
 
       if args[:xstools] == '1'
         # Add xs-tools ISO to newly created VMs
-        dvd_vdi = client.vdis.find { |isovdi| isovdi.name == 'xs-tools.iso' }
+        dvd_vdi = client.vdis.find { |isovdi| isovdi.name == 'xs-tools.iso' or isovdi.name == 'guest-tools.iso' }
         vbdconnectcd = {
           'vdi'                  => dvd_vdi,
           'vm'                   => vm.reference,

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -315,7 +315,7 @@ module ForemanXen
 
       if args[:xstools] == '1'
         # Add xs-tools ISO to newly created VMs
-        dvd_vdi = client.vdis.find { |isovdi| isovdi.name == 'xs-tools.iso' or isovdi.name == 'guest-tools.iso' }
+        dvd_vdi = client.vdis.find { |isovdi| isovdi.name == 'xs-tools.iso' || isovdi.name == 'guest-tools.iso' }
         vbdconnectcd = {
           'vdi'                  => dvd_vdi,
           'vm'                   => vm.reference,

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -168,7 +168,7 @@ module ForemanXen
       end
       retval = []
       tmps.each do |snapshot|
-	retval << snapshot if snapshot.snapshot_metadata.include?(vm.uuid)
+        retval << snapshot if snapshot.snapshot_metadata.include?(vm.uuid)
       end
       retval
     end


### PR DESCRIPTION
As snapshot uuids are not in VM properties, snapshot listing does not work. This patch changes the approch by searching vm uuid in snapshot metadatas and makes snapshot listing works.
