### PR TITLE
Fixes #18015 - Workaround for fog-xenserver clone bug

### DIFF
--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -260,7 +260,9 @@ module ForemanXen
         vm.set_attribute('memory_static_max', mem_max)
       end
 
-      disks = vm.vbds.select { |vbd| vbd.type == 'Disk' }
+      # workaround for fog-xenserver bug. when calling clone method, the returned object references
+      # VBD from the template instead of the clone
+      disks = find_vm_by_uuid(vm.reference).vbds.select { |vbd| vbd.type == 'Disk' }
       disks.sort! { |a, b| a.userdevice <=> b.userdevice }
       i = 0
       disks.each do |vbd|


### PR DESCRIPTION
When cloning a template, fog-xenserver is not updating the list of VBDs attached to the new VM.
This was causing fog-xenserver to rename the VDI on the template rather than the newly created VM.
This should be fixed in fog-xenserver but for now we fetch the newly created VM by reference, and
get the VBD/VDI from that.