### PR TITLE
support Foreman >= 1.17 with fog-xenserver = 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rubocop', '~> 0.54.0', require: false
+
+group :fog do
+  gem 'fog-xenserver', '1.0.0', :require => false
+end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -368,8 +368,7 @@ module ForemanXen
     protected
 
     def client
-      @client ||= ::Fog::Compute.new(
-        :provider                     => 'XenServer',
+      @client ||= Fog::XenServer::Compute.new(
         :xenserver_url                => url,
         :xenserver_username           => user,
         :xenserver_password           => password,

--- a/foreman_xen.gemspec
+++ b/foreman_xen.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.description = 'Provision and manage XEN Server from Foreman.'
   s.licenses    = ['GPL-3']
 
-  s.add_dependency 'fog-xenserver', '~> 0.2'
   s.add_development_dependency('rake')
 
   s.files = Dir['{app,config,db,lib,locale}/**/*', 'LICENSE', 'Rakefile', 'README.md']

--- a/lib/foreman_xen/engine.rb
+++ b/lib/foreman_xen/engine.rb
@@ -42,11 +42,11 @@ module ForemanXen
     config.to_prepare do
       begin
         # extend fog xen server and image models.
-        require 'fog/compute/xen_server/models/server'
+        require 'fog/xenserver/compute/models/server'
         require File.expand_path('../../app/models/concerns/fog_extensions/xenserver/server', __dir__)
         require File.expand_path('../../app/models/concerns/foreman_xen/host_helper_extensions', __dir__)
 
-        Fog::Compute::XenServer::Server.send(:include, ::FogExtensions::Xenserver::Server)
+        Fog::XenServer::Compute::Server.send(:include, ::FogExtensions::Xenserver::Server)
         ::HostsHelper.send(:include, ForemanXen::HostHelperExtensions)
       rescue => e
         Rails.logger.warn "Foreman-Xen: skipping engine hook (#{e})"


### PR DESCRIPTION
Use fog-xenserver 1.0.0 which works as standalone with fog. It's now compatible with Foreman >= 1.17.