### PR TITLE
fix errors introduced by linting; fix vm import

### DIFF
--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -13,6 +13,10 @@ module FogExtensions
         uuid
       end
 
+      def identity
+        uuid
+      end
+
       def to_s
         name
       end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -52,8 +52,11 @@ module ForemanXen
       end
     end
 
+    # rubocop:disable Rails/DynamicFindBy
+    # Fog::XenServer::Compute (client) isn't an ActiveRecord model which
+    # supports find_by()
     def find_vm_by_uuid(uuid)
-      client.servers.find_by(uuid: uuid)
+      client.servers.find_by_uuid(uuid)
     rescue Fog::XenServer::RequestFailed => e
       Foreman::Logging.exception("Failed retrieving xenserver vm by uuid #{uuid}", e)
       raise(ActiveRecord::RecordNotFound) if e.message.include?('HANDLE_INVALID')
@@ -61,6 +64,7 @@ module ForemanXen
 
       raise e
     end
+    # rubocop:enable Rails/DynamicFindBy
 
     # we default to destroy the VM's storage as well.
     def destroy_vm(ref, args = {})
@@ -526,13 +530,17 @@ module ForemanXen
       out_hash
     end
 
+    # rubocop:disable Rails/DynamicFindBy
+    # Fog::XenServer::Compute (client) isn't an ActiveRecord model which
+    # supports find_by()
     def set_vm_affinity(vm, hypervisor)
       if hypervisor.empty?
         vm.set_attribute('affinity', '')
       else
-        vm.set_attribute('affinity', client.hosts.find_by(uuid: hypervisor))
+        vm.set_attribute('affinity', client.hosts.find_by_uuid(hypervisor))
       end
     end
+    # rubocop:enable Rails/DynamicFindBy
 
     def create_and_attach_configdrive(vm, attr)
       network_data = add_mac_to_network_data(attr[:network_data], vm)

--- a/app/views/compute_resources_vms/index/_xenserver.html.erb
+++ b/app/views/compute_resources_vms/index/_xenserver.html.erb
@@ -11,7 +11,7 @@
   <tbody>
   <% @vms.each do |vm| -%>
       <tr>
-        <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity) %></td>
+        <td><%= link_to_if_authorized vm.name, hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.uuid) %></td>
         <td><%= vm.vcpus_max %></td>
         <td><%= (vm.memory_static_max.to_i / 1073741824).to_s %> GB</td>
         <td><%= vm.power_state %> </td>


### PR DESCRIPTION
Hi Michael

Our testing shows that the changes applied to make rubocop happy introduced a bug. The method recommended by the linter does not exist.  This reverts the two affected lines.
While fixing, I found another bug that occurs when trying to import a vm from a compute resource.

They should both be fixed with this commit.