### PR TITLE
use helper to generate urls

### DIFF
--- a/app/views/compute_resources_vms/form/_hypervisors.html.erb
+++ b/app/views/compute_resources_vms/form/_hypervisors.html.erb
@@ -8,7 +8,8 @@
           disabled: (controller_name != 'hosts'),
           label: _("Hypervisor"), },
         { title: 'Refresh available hypervisors',
-          url: '/foreman_xen/cache/refresh',
+          url: url_for(controller: "foreman_xen/cache",
+                       action: "refresh", only_path: true),
           compute_resource_id: compute_resource.id,
           attribute: 'available_hypervisors' }
       ) %>

--- a/app/views/compute_resources_vms/form/_image_provisioning.html.erb
+++ b/app/views/compute_resources_vms/form/_image_provisioning.html.erb
@@ -13,7 +13,8 @@
           { class: "span2",
             label: _("Target Repository"), },
           { title: 'Refresh available storage repositories',
-            url: '/foreman_xen/cache/refresh',
+            url: url_for(controller: "foreman_xen/cache",
+                         action: "refresh", only_path: true),
             compute_resource_id: compute_resource.id,
             attribute: 'storage_pools' }
         ) %>

--- a/app/views/compute_resources_vms/form/_isos.html.erb
+++ b/app/views/compute_resources_vms/form/_isos.html.erb
@@ -7,7 +7,8 @@
         { class: "span2",
           label: _('Attach ISO'), },
         { title: 'Refresh available storage repositories',
-          url: '/foreman_xen/cache/refresh',
+          url: url_for(controller: "foreman_xen/cache",
+                       action: "refresh", only_path: true),
           compute_resource_id: compute_resource.id,
           attribute: 'isos' }
       ) %>

--- a/app/views/compute_resources_vms/form/_network_provisioning.html.erb
+++ b/app/views/compute_resources_vms/form/_network_provisioning.html.erb
@@ -9,7 +9,8 @@
             prompt: 'No Template'},
           { class: 'span2', label: 'VM Template' },
           { title: 'Refresh available builtin templates',
-            url: '/foreman_xen/cache/refresh',
+            url: url_for(controller: "foreman_xen/cache",
+                         action: "refresh", only_path: true),
             compute_resource_id: compute_resource.id,
             attribute: 'builtin_templates' }
          ) %>

--- a/app/views/compute_resources_vms/form/_templates.html.erb
+++ b/app/views/compute_resources_vms/form/_templates.html.erb
@@ -8,7 +8,8 @@
             { prompt: 'Select a Template'},
             { class: 'span2', label: 'Builtin Template' },
             { title: 'Refresh available builtin templates',
-              url: '/foreman_xen/cache/refresh',
+              url: url_for(controller: "foreman_xen/cache",
+                           action: "refresh", only_path: true),
               compute_resource_id: compute_resource.id,
               attribute: 'builtin_templates' }
            ) %>

--- a/app/views/compute_resources_vms/form/xenserver/_network.html.erb
+++ b/app/views/compute_resources_vms/form/xenserver/_network.html.erb
@@ -11,7 +11,8 @@
             sizer: 'col-md-8',
             disabled: (controller_name != 'hosts') },
           { title: 'Refresh available networks',
-            url: '/foreman_xen/cache/refresh',
+            url: url_for(controller: "foreman_xen/cache",
+                         action: "refresh", only_path: true),
             compute_resource_id: compute_resource.id,
             attribute: 'networks' }
     %>

--- a/app/views/compute_resources_vms/form/xenserver/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/xenserver/_volume.html.erb
@@ -6,7 +6,8 @@
       { class: 'span2',
         label: _("Storage Repository") },
       { title: 'Refresh available storage repositories',
-        url: '/foreman_xen/cache/refresh',
+        url: url_for(controller: "foreman_xen/cache",
+                     action: "refresh", only_path: true),
         compute_resource_id: compute_resource.id,
         attribute: 'storage_pools' }
 %>


### PR DESCRIPTION
As per @ekohl's comment in #63 the urls to the foreman_xen/cache/refresh are now generated by the url_for helper to avoid problems when foreman is not mounted to the / url.