### PR TITLE
remove fog server identity override; accept vm references in find_vm_by_uuid

### DIFF
--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -13,10 +13,6 @@ module FogExtensions
         uuid
       end
 
-      def identity
-        uuid
-      end
-
       def to_s
         name
       end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -56,6 +56,8 @@ module ForemanXen
     # Fog::XenServer::Compute (client) isn't an ActiveRecord model which
     # supports find_by()
     def find_vm_by_uuid(uuid)
+      return client.servers.find { |s| s.reference == uuid } if uuid.start_with? 'OpaqueRef:'
+
       client.servers.find_by_uuid(uuid)
     rescue Fog::XenServer::RequestFailed => e
       Foreman::Logging.exception("Failed retrieving xenserver vm by uuid #{uuid}", e)


### PR DESCRIPTION

Sorry Guys, I rushed #64 yesterday and didn't test it well.
Overwriting `identity` in the fog concern was a big mistake and broke several things.

The problem is, that foreman sometimes uses `vm.uuid`, sometimes `vm.id` and sometimes `vm.identity` an expects the same behaviour every time.
`identity` is however used by fog internally and must return the reference and not the uuid.

By patching find_vm_by_uuid to also accept references, this gets masked from foreman and the behaviour does get consistent, no matter which method it's calling.

Sorry for that, this should now be the last patch for 1.0.0.