### PR TITLE
Revert "remove fog server identity override; accept vm references in …

### DIFF
--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -13,6 +13,10 @@ module FogExtensions
         uuid
       end
 
+      def identity
+        uuid
+      end
+
       def to_s
         name
       end

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -56,8 +56,6 @@ module ForemanXen
     # Fog::XenServer::Compute (client) isn't an ActiveRecord model which
     # supports find_by()
     def find_vm_by_uuid(uuid)
-      return client.servers.find { |s| s.reference == uuid } if uuid.start_with? 'OpaqueRef:'
-
       client.servers.find_by_uuid(uuid)
     rescue Fog::XenServer::RequestFailed => e
       Foreman::Logging.exception("Failed retrieving xenserver vm by uuid #{uuid}", e)


### PR DESCRIPTION
This reverts commit 5ed96188624962c5745d0ded6fdbe8fdc8dcb0d3.

I can't see any rationale provided for the change in this commit, and reverting it fixes VM assocation.

Fixes: https://projects.theforeman.org/issues/27458
