### PR TITLE
fix for manual hypervisor selection

### DIFF
--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -539,7 +539,7 @@ module ForemanXen
       if hypervisor.empty?
         vm.set_attribute('affinity', '')
       else
-        vm.set_attribute('affinity', client.hosts.find_by_uuid(hypervisor))
+        vm.set_attribute('affinity', hypervisor)
       end
     end
     # rubocop:enable Rails/DynamicFindBy


### PR DESCRIPTION
Currently the plugin fails to provision when a hypervisor is selected. This change fixes it.