### PR TITLE
Remove deprecated jquery ui spinner

### DIFF
--- a/app/views/compute_resources_vms/form/xenserver/_base.html.erb
+++ b/app/views/compute_resources_vms/form/xenserver/_base.html.erb
@@ -1,6 +1,5 @@
 <% compute_attributes = compute_attributes_from_params(compute_resource) -%>
 <%= javascript_include_tag 'foreman_xen/xenserver/cache_refresh' %>
-<%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
 
 <!-- VM Profile -->
 <div class="children_fields">


### PR DESCRIPTION
As part of this change:
theforeman/foreman#8538

removed the deprecated parts.