### PR TITLE
Make puppet environment optional.

### DIFF
--- a/app/models/concerns/fog_extensions/xenserver/network.rb
+++ b/app/models/concerns/fog_extensions/xenserver/network.rb
@@ -1,0 +1,11 @@
+module FogExtensions
+  module Xenserver
+    module Network
+      extend ActiveSupport::Concern
+
+      def id
+        uuid
+      end
+    end
+  end
+end

--- a/app/models/concerns/fog_extensions/xenserver/server.rb
+++ b/app/models/concerns/fog_extensions/xenserver/server.rb
@@ -57,6 +57,7 @@ module FogExtensions
       end
 
       def interfaces
+        @interfaces ||= []
         (vifs + @interfaces).uniq
       end
 

--- a/app/models/concerns/fog_extensions/xenserver/storage_repository.rb
+++ b/app/models/concerns/fog_extensions/xenserver/storage_repository.rb
@@ -8,6 +8,10 @@ module FogExtensions
         prepend FogExtensions::Xenserver::StorageRepository
       end
 
+      def id
+        uuid
+      end
+
       def initialize(new_attributes = {})
         super(new_attributes)
         attributes[:display_name] = init_display_name
@@ -27,6 +31,14 @@ module FogExtensions
 
       def physical_utilisation_gb
         physical_utilisation.to_i / 1024 / 1024 / 1024
+      end
+
+      def capacity
+        physical_size_gb
+      end
+
+      def freespace
+        free_space
       end
 
       def init_display_name

--- a/app/models/concerns/foreman_xen/host_extensions.rb
+++ b/app/models/concerns/foreman_xen/host_extensions.rb
@@ -3,7 +3,10 @@ module ForemanXen
     extend ActiveSupport::Concern
 
     def built(installed = true)
-      compute_resource.cleanup_configdrive(uuid) if compute_resource && compute_resource.type == 'ForemanXen::Xenserver'
+      if compute_resource && compute_resource.type == 'ForemanXen::Xenserver'
+        compute_resource.detach_cdrom(uuid)
+        compute_resource.cleanup_configdrive(uuid)
+      end
       super(installed)
     end
 

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -518,7 +518,7 @@ module ForemanXen
                                                'netmask' => subnet.nil? ? '' : subnet.mask } } },
         'nameserver1' => subnet.nil? ? '' : subnet.dns_primary,
         'nameserver2' => subnet.nil? ? '' : subnet.dns_secondary,
-        'environment' => !host.respond_to?("environment")? ? '' : host.environment.to_s }
+        'environment' => !host.respond_to?("environment") ? '' : host.environment.to_s }
     end
 
     def xenstore_hash_flatten(nested_hash, _key = nil, keychain = nil, out_hash = {})

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -39,6 +39,15 @@ module ForemanXen
       attrs[:iso_library_mountpoint] = mountpoint
     end
 
+    def detach_cdrom(uuid)
+      begin
+        vm = find_vm_by_uuid(uuid)
+        detach_cdrom_vbd(vm) if vm
+      rescue => e
+        logger.error "unable to detach cdrom:#{e}"
+      end
+    end
+
     def cleanup_configdrive(uuid)
       iso_file_name = "foreman-configdrive-#{uuid}.iso"
       begin
@@ -108,6 +117,14 @@ module ForemanXen
 
     def available_images
       custom_templates!
+    end
+
+    def available_storage_domains(*)
+      storage_pools
+    end
+
+    def available_networks(*)
+      networks
     end
 
     def available_hypervisors
@@ -273,8 +290,8 @@ module ForemanXen
       {
         name:               args[:name],
         name_description:   args[:comment],
-        vcpus_max:          args[:vcpus_max],
-        vcpus_at_startup:   args[:vcpus_max],
+        VCPUs_max:          args[:vcpus_max],
+        VCPUs_at_startup:   args[:vcpus_max],
         memory_static_max:  args[:memory_max],
         memory_dynamic_max: args[:memory_max],
         memory_dynamic_min: args[:memory_min],
@@ -374,9 +391,9 @@ module ForemanXen
       mem = %w[memory_static_max memory_dynamic_max
                memory_dynamic_min memory_static_min]
       mem.reverse! if vm.memory_static_max.to_i > attr[:memory_static_max].to_i
-      # VCPU values must satisfy: 0 < vcpus_at_startup <= vcpus_max
-      cpu = %w[vcpus_max vcpus_at_startup]
-      cpu.reverse! if vm.vcpus_at_startup > attr[:vcpus_at_startup]
+      # VCPU values must satisfy: 0 < VCPUs_at_startup <= VCPUs_max
+      cpu = %w[VCPUs_max VCPUs_at_startup]
+      cpu.reverse! if vm.vcpus_at_startup > attr[:VCPUs_at_startup]
       (mem + cpu).each { |e| vm.set_attribute e, attr[e.to_sym] }
     end
 
@@ -487,6 +504,13 @@ module ForemanXen
         client.vbds.create vbd
       end
       true
+    end
+
+    def detach_cdrom_vbd(vm)
+      cd_drive = client.vbds.find { |v| v.vm == vm && v.type == 'CD' }
+      unless cd_drive&.empty
+        client.eject_vbd cd_drive.reference
+      end
     end
 
     def find_free_userdevice(vm)

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -518,7 +518,7 @@ module ForemanXen
                                                'netmask' => subnet.nil? ? '' : subnet.mask } } },
         'nameserver1' => subnet.nil? ? '' : subnet.dns_primary,
         'nameserver2' => subnet.nil? ? '' : subnet.dns_secondary,
-        'environment' => host.environment.to_s }
+        'environment' => !host.respond_to?("environment")? ? '' : host.environment.to_s }
     end
 
     def xenstore_hash_flatten(nested_hash, _key = nil, keychain = nil, out_hash = {})

--- a/app/models/foreman_xen/xenserver.rb
+++ b/app/models/foreman_xen/xenserver.rb
@@ -539,7 +539,7 @@ module ForemanXen
       if hypervisor.empty?
         vm.set_attribute('affinity', '')
       else
-        vm.set_attribute('affinity', client.hosts.find_by_uuid(hypervisor))
+        vm.set_attribute('affinity', hypervisor)
       end
     end
     # rubocop:enable Rails/DynamicFindBy

--- a/app/views/compute_resources_vms/form/_network_provisioning.html.erb
+++ b/app/views/compute_resources_vms/form/_network_provisioning.html.erb
@@ -1,5 +1,5 @@
 <!-- VM Template -->
-<div class="network_fields" style="display:none">
+<div class="network_fields">
   <div id="vm_template_selection">
     <%= selectable_f_with_cache_invalidation(f, :builtin_template,
           options_from_collection_for_select(

--- a/app/views/compute_resources_vms/form/xenserver/_base.html.erb
+++ b/app/views/compute_resources_vms/form/xenserver/_base.html.erb
@@ -1,6 +1,5 @@
 <% compute_attributes = compute_attributes_from_params(compute_resource) -%>
 <%= javascript_include_tag 'foreman_xen/xenserver/cache_refresh' %>
-<%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
 
 <!-- VM Profile -->
 <div class="children_fields">

--- a/lib/foreman_xen/engine.rb
+++ b/lib/foreman_xen/engine.rb
@@ -45,10 +45,12 @@ module ForemanXen
         require 'fog/xenserver/compute/models/server'
         require 'fog/xenserver/compute/models/host'
         require 'fog/xenserver/compute/models/vdi'
+        require 'fog/xenserver/compute/models/network'
         require 'fog/xenserver/compute/models/storage_repository'
         require File.expand_path('../../app/models/concerns/fog_extensions/xenserver/server', __dir__)
         require File.expand_path('../../app/models/concerns/fog_extensions/xenserver/host', __dir__)
         require File.expand_path('../../app/models/concerns/fog_extensions/xenserver/vdi', __dir__)
+        require File.expand_path('../../app/models/concerns/fog_extensions/xenserver/network', __dir__)
         require File.expand_path('../../app/models/concerns/fog_extensions/xenserver/storage_repository', __dir__)
         require File.expand_path('../../app/models/concerns/foreman_xen/host_helper_extensions', __dir__)
         require File.expand_path('../../app/models/concerns/foreman_xen/host_extensions', __dir__)
@@ -56,6 +58,7 @@ module ForemanXen
         Fog::XenServer::Compute::Models::Server.include ::FogExtensions::Xenserver::Server
         Fog::XenServer::Compute::Models::Host.include ::FogExtensions::Xenserver::Host
         Fog::XenServer::Compute::Models::Vdi.include ::FogExtensions::Xenserver::Vdi
+        Fog::XenServer::Compute::Models::Network.include ::FogExtensions::Xenserver::Network
         Fog::XenServer::Compute::Models::StorageRepository.include ::FogExtensions::Xenserver::StorageRepository
         ::HostsHelper.include ForemanXen::HostHelperExtensions
         ::Host::Managed.prepend ForemanXen::HostExtensions

--- a/lib/foreman_xen/engine.rb
+++ b/lib/foreman_xen/engine.rb
@@ -16,11 +16,13 @@ module ForemanXen
     end
 
     initializer 'foreman_xen.register_plugin', :before => :finisher_hook do |app|
-      Foreman::Plugin.register :foreman_xen do
-        requires_foreman '>= 1.20'
-        # Register xen compute resource in foreman
-        compute_resource ForemanXen::Xenserver
-        parameter_filter(ComputeResource, :uuid, :iso_library_mountpoint)
+      app.reloader.to_prepare do
+        Foreman::Plugin.register :foreman_xen do
+          requires_foreman '>= 1.20'
+          # Register xen compute resource in foreman
+          compute_resource ForemanXen::Xenserver
+          parameter_filter(ComputeResource, :uuid, :iso_library_mountpoint)
+        end
       end
     end
 


### PR DESCRIPTION
Foreman no longer requires puppet to manage hosts.  In fact, it is possible to purge puppet completely from a foreman installation (see https://docs.theforeman.org/3.1/Managing_Configurations_Puppet/index-katello.html#Disabling_Puppet_Integration_managing-configurations-puppet ) which is what I have done.  Doing so breaks VM creation.

This patch makes the puppet environment variable optional.  I'm not sure why the environment was required or used before, but I haven't noticed any ill effects yet.